### PR TITLE
MANTRUN-221 Fails to pass maven properties set in user properties only

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -127,6 +127,7 @@ under the License.
           <configuration>
             <excludes combine.children="append">
               <exclude>src/test/resources/configuration-writer/*.xml</exclude>
+              <exclude>src/it/*/*.json</exclude>
             </excludes>
           </configuration>
         </plugin>

--- a/src/it/MANTRUN-221/build.xml
+++ b/src/it/MANTRUN-221/build.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<project name="MANTRUN-221" default="main">
+  <condition property="isProp1Ok">
+    <equals arg1="${prop1}" arg2="3.2.1" />
+  </condition>
+
+  <target name="-prop1" unless="isProp1Ok">
+    <fail>prop1=${prop1} is not equal to 3.2.1</fail>
+  </target>
+
+  <target name="main" depends="-prop1" />
+</project>

--- a/src/it/MANTRUN-221/invoker.properties
+++ b/src/it/MANTRUN-221/invoker.properties
@@ -1,0 +1,18 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+invoker.goals = clean validate

--- a/src/it/MANTRUN-221/package.json
+++ b/src/it/MANTRUN-221/package.json
@@ -1,0 +1,4 @@
+{
+    "_license": "Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements; and to You under the Apache License, Version 2.0. ",
+    "version": "3.2.1"
+}

--- a/src/it/MANTRUN-221/pom.xml
+++ b/src/it/MANTRUN-221/pom.xml
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>org.apache.maven.plugins.antrun</groupId>
+  <artifactId>MANTRUN-221</artifactId>
+  <packaging>pom</packaging>
+  <version>1.0</version>
+  <url>https://issues.apache.org/jira/browse/MANTRUN-221</url>
+  <description>
+    Checks that properties defined at build time are passed to Ant invocation
+  </description>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>ca.szc.maven</groupId>
+        <artifactId>jsonpath-maven-plugin</artifactId>
+        <version>1.0.0</version>
+        <executions>
+          <execution>
+            <id>read-properties</id>
+            <phase>validate</phase>
+            <goals>
+              <goal>set-properties</goal>
+            </goals>
+            <configuration>
+              <file>package.json</file>
+              <properties>
+                <prop1>$.version</prop1>
+              </properties>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <artifactId>maven-antrun-plugin</artifactId>
+        <version>@pom.version@</version>
+        <executions>
+          <execution>
+            <phase>validate</phase>
+            <goals>
+              <goal>run</goal>
+            </goals>
+            <configuration>
+              <target>
+                <ant antfile="build.xml" />
+              </target>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/src/main/java/org/apache/maven/plugins/antrun/AntRunMojo.java
+++ b/src/main/java/org/apache/maven/plugins/antrun/AntRunMojo.java
@@ -418,7 +418,9 @@ public class AntRunMojo
     {
         Properties mavenProps = mavenProject.getProperties();
         Properties userProps = session.getUserProperties();
-        for ( String key : mavenProps.stringPropertyNames() )
+        List<String> allPropertyKeys = new ArrayList<String>( mavenProps.stringPropertyNames() );
+        allPropertyKeys.addAll( userProps.stringPropertyNames() );
+        for ( String key : allPropertyKeys )
         {
             String value = userProps.getProperty( key, mavenProps.getProperty( key ) );
             antProject.setProperty( key, value );


### PR DESCRIPTION
This resolves a bug introduced by MANTRUN-178, where it incorrectly
assumes that mavenProject.getProperties() will contain all properties
present in the session.

I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)

