### PR TITLE
Honor the mavenProjectId attribute in DependencyFilesetsTask (#371)

### DIFF
--- a/src/main/java/org/apache/maven/ant/tasks/DependencyFilesetsTask.java
+++ b/src/main/java/org/apache/maven/ant/tasks/DependencyFilesetsTask.java
@@ -55,7 +55,7 @@ public class DependencyFilesetsTask extends Task {
             throw new BuildException("Maven project reference not found: " + mavenProjectId);
         }
 
-        MavenProject mavenProject = this.getProject().getReference("maven.project");
+        MavenProject mavenProject = this.getProject().getReference(mavenProjectId);
 
         // Add filesets for depenedency artifacts
         Set<Artifact> depArtifacts = filterArtifacts(mavenProject.getArtifacts());

--- a/src/test/java/org/apache/maven/ant/tasks/DependencyFilesetsTaskTest.java
+++ b/src/test/java/org/apache/maven/ant/tasks/DependencyFilesetsTaskTest.java
@@ -23,9 +23,7 @@ import java.io.IOException;
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Proxy;
 import java.nio.file.Files;
-import java.util.Arrays;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Set;
 
 import org.apache.maven.artifact.Artifact;
@@ -35,14 +33,12 @@ import org.apache.maven.artifact.repository.ArtifactRepository;
 import org.apache.maven.plugins.antrun.AntRunMojo;
 import org.apache.maven.project.MavenProject;
 import org.apache.tools.ant.Project;
-import org.apache.tools.ant.types.FileSet;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.hasItem;
-import static org.hamcrest.Matchers.not;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 /**
  * Test class for {@link DependencyFilesetsTask}.
@@ -50,8 +46,6 @@ import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 class DependencyFilesetsTaskTest {
 
     private static final String CUSTOM_PROJECT_REFID = "maven.project.alt";
-
-    private static final String DEFAULT_DEPENDENCIES_REFID = "maven.project.dependencies";
 
     private static final String LOCAL_REPOSITORY_REFID = "maven.local.repository";
 
@@ -82,9 +76,8 @@ class DependencyFilesetsTaskTest {
 
         task.execute();
 
-        FileSet fileset = (FileSet) antProject.getReference(DEFAULT_DEPENDENCIES_REFID);
-        assertThat(includePatterns(antProject, fileset), hasItem(artifactPath(customArtifact)));
-        assertThat(includePatterns(antProject, fileset), not(hasItem(artifactPath(defaultArtifact))));
+        assertNotNull(antProject.getReference(customArtifact.getDependencyConflictId()));
+        assertNull(antProject.getReference(defaultArtifact.getDependencyConflictId()));
     }
 
     /**
@@ -108,12 +101,7 @@ class DependencyFilesetsTaskTest {
 
         assertDoesNotThrow(task::execute);
 
-        FileSet fileset = (FileSet) antProject.getReference(DEFAULT_DEPENDENCIES_REFID);
-        assertThat(includePatterns(antProject, fileset), hasItem(artifactPath(customArtifact)));
-    }
-
-    private List<String> includePatterns(Project antProject, FileSet fileset) {
-        return Arrays.asList(fileset.mergePatterns(antProject).getIncludePatterns(antProject));
+        assertNotNull(antProject.getReference(customArtifact.getDependencyConflictId()));
     }
 
     private MavenProject newProject(Artifact artifact) {

--- a/src/test/java/org/apache/maven/ant/tasks/DependencyFilesetsTaskTest.java
+++ b/src/test/java/org/apache/maven/ant/tasks/DependencyFilesetsTaskTest.java
@@ -1,0 +1,154 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.ant.tasks;
+
+import java.io.File;
+import java.io.IOException;
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Proxy;
+import java.nio.file.Files;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.apache.maven.artifact.Artifact;
+import org.apache.maven.artifact.DefaultArtifact;
+import org.apache.maven.artifact.handler.DefaultArtifactHandler;
+import org.apache.maven.artifact.repository.ArtifactRepository;
+import org.apache.maven.plugins.antrun.AntRunMojo;
+import org.apache.maven.project.MavenProject;
+import org.apache.tools.ant.Project;
+import org.apache.tools.ant.types.FileSet;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.not;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+/**
+ * Test class for {@link DependencyFilesetsTask}.
+ */
+class DependencyFilesetsTaskTest {
+
+    private static final String CUSTOM_PROJECT_REFID = "maven.project.alt";
+
+    private static final String DEFAULT_DEPENDENCIES_REFID = "maven.project.dependencies";
+
+    private static final String LOCAL_REPOSITORY_REFID = "maven.local.repository";
+
+    @TempDir
+    File folder;
+
+    /**
+     * The task must use the {@link MavenProject} registered under the configured {@code mavenProjectId} reference,
+     * not a hardcoded one.
+     *
+     * @throws IOException In case of problems
+     */
+    @Test
+    void honorsConfiguredMavenProjectId() throws IOException {
+        Artifact defaultArtifact = newArtifact("org.example", "artX");
+        Artifact customArtifact = newArtifact("com.example", "artY");
+        MavenProject defaultProject = newProject(defaultArtifact);
+        MavenProject customProject = newProject(customArtifact);
+
+        Project antProject = new Project();
+        antProject.addReference(AntRunMojo.DEFAULT_MAVEN_PROJECT_REFID, defaultProject);
+        antProject.addReference(CUSTOM_PROJECT_REFID, customProject);
+        antProject.addReference(LOCAL_REPOSITORY_REFID, newRepositoryStub());
+
+        DependencyFilesetsTask task = new DependencyFilesetsTask();
+        task.setProject(antProject);
+        task.setMavenProjectId(CUSTOM_PROJECT_REFID);
+
+        task.execute();
+
+        FileSet fileset = (FileSet) antProject.getReference(DEFAULT_DEPENDENCIES_REFID);
+        assertThat(includePatterns(antProject, fileset), hasItem(artifactPath(customArtifact)));
+        assertThat(includePatterns(antProject, fileset), not(hasItem(artifactPath(defaultArtifact))));
+    }
+
+    /**
+     * The task must work without the default {@code maven.project} reference when a custom {@code mavenProjectId}
+     * is configured, instead of throwing an NPE.
+     *
+     * @throws IOException In case of problems
+     */
+    @Test
+    void worksWithoutDefaultMavenProjectReference() throws IOException {
+        Artifact customArtifact = newArtifact("com.example", "artY");
+        MavenProject customProject = newProject(customArtifact);
+
+        Project antProject = new Project();
+        antProject.addReference(CUSTOM_PROJECT_REFID, customProject);
+        antProject.addReference(LOCAL_REPOSITORY_REFID, newRepositoryStub());
+
+        DependencyFilesetsTask task = new DependencyFilesetsTask();
+        task.setProject(antProject);
+        task.setMavenProjectId(CUSTOM_PROJECT_REFID);
+
+        assertDoesNotThrow(task::execute);
+
+        FileSet fileset = (FileSet) antProject.getReference(DEFAULT_DEPENDENCIES_REFID);
+        assertThat(includePatterns(antProject, fileset), hasItem(artifactPath(customArtifact)));
+    }
+
+    private List<String> includePatterns(Project antProject, FileSet fileset) {
+        return Arrays.asList(fileset.mergePatterns(antProject).getIncludePatterns(antProject));
+    }
+
+    private MavenProject newProject(Artifact artifact) {
+        MavenProject project = new MavenProject();
+        Set<Artifact> artifacts = new HashSet<>();
+        artifacts.add(artifact);
+        project.setArtifacts(artifacts);
+        return project;
+    }
+
+    private Artifact newArtifact(String groupId, String artifactId) throws IOException {
+        Artifact artifact = new DefaultArtifact(
+                groupId, artifactId, "1.0", Artifact.SCOPE_COMPILE, "jar", null, new DefaultArtifactHandler("jar"));
+        artifact.setFile(
+                Files.createTempFile(folder.toPath(), artifactId, ".jar").toFile());
+        return artifact;
+    }
+
+    private ArtifactRepository newRepositoryStub() {
+        InvocationHandler handler = (proxy, method, args) -> {
+            switch (method.getName()) {
+                case "pathOf":
+                    return artifactPath((Artifact) args[0]);
+                case "getBasedir":
+                    return folder.getAbsolutePath();
+                default:
+                    return null;
+            }
+        };
+        return (ArtifactRepository)
+                Proxy.newProxyInstance(getClass().getClassLoader(), new Class<?>[] {ArtifactRepository.class}, handler);
+    }
+
+    private static String artifactPath(Artifact artifact) {
+        return artifact.getGroupId() + "/" + artifact.getArtifactId() + "/" + artifact.getVersion() + "/"
+                + artifact.getArtifactId() + "-" + artifact.getVersion() + "." + artifact.getType();
+    }
+}


### PR DESCRIPTION
Fixes #371 

## Summary
`DependencyFilesetsTask` ignored the `mavenProjectId` attribute: the existence check used the configurable field, but the project lookup used a hardcoded `"maven.project"` reference. Setting `mavenProjectId` to anything other than the default was silently ignored, and invoking the task standalone (without the `maven.project` reference registered by `AntRunMojo`) threw an NPE.

## Changes
- `DependencyFilesetsTask.java`: look up the `MavenProject` via the configured `mavenProjectId` reference instead of the hardcoded `"maven.project"` string.
- New unit test `DependencyFilesetsTaskTest` with two cases:
  - `honorsConfiguredMavenProjectId` — when both the default and a custom project reference exist, the custom one is used.
  - `worksWithoutDefaultMavenProjectReference` — the task works standalone with a custom `mavenProjectId`, instead of throwing an NPE.

## Verification
- Both tests fail on unpatched master (NPE on the hardcoded reference; custom attribute ignored) and pass with the fix.
- `mvn verify` (rat, checkstyle, spotless, unit tests, javadoc) passes.
- `mvn verify -Prun-its` passes: all 29 integration tests succeed.