### PR TITLE
Handle plain MavenProject reference in AttachArtifactTask (#375)

### DIFF
--- a/src/main/java/org/apache/maven/ant/tasks/AttachArtifactTask.java
+++ b/src/main/java/org/apache/maven/ant/tasks/AttachArtifactTask.java
@@ -68,8 +68,7 @@ public class AttachArtifactTask extends Task {
             type = FileUtils.getExtension(file.getName());
         }
 
-        MavenProject mavenProject =
-                ((MavenAntRunProject) this.getProject().getReference(mavenProjectRefId)).getMavenProject();
+        MavenProject mavenProject = getMavenProject();
 
         if (this.getProject().getReference(mavenProjectHelperRefId) == null) {
             throw new BuildException("Maven project helper reference not found: " + mavenProjectHelperRefId);
@@ -79,6 +78,25 @@ public class AttachArtifactTask extends Task {
         log("Attaching " + file + " as an attached artifact", Project.MSG_VERBOSE);
         MavenProjectHelper projectHelper = getProject().getReference(mavenProjectHelperRefId);
         projectHelper.attachArtifact(mavenProject, type, classifier, file);
+    }
+
+    /**
+     * Resolves the Maven project from the configured reference, unwrapping the {@link MavenAntRunProject} wrapper if
+     * present. The reference may hold either a {@link MavenProject} or a {@link MavenAntRunProject}; any other type is
+     * rejected with a {@link BuildException}.
+     *
+     * @return the Maven project held by the reference
+     */
+    private MavenProject getMavenProject() {
+        Object reference = this.getProject().getReference(mavenProjectRefId);
+        if (reference instanceof MavenAntRunProject) {
+            return ((MavenAntRunProject) reference).getMavenProject();
+        }
+        if (reference instanceof MavenProject) {
+            return (MavenProject) reference;
+        }
+        throw new BuildException(
+                "Maven project reference is not a MavenProject or MavenAntRunProject: " + mavenProjectRefId);
     }
 
     /**

--- a/src/test/java/org/apache/maven/ant/tasks/AttachArtifactTaskTest.java
+++ b/src/test/java/org/apache/maven/ant/tasks/AttachArtifactTaskTest.java
@@ -1,0 +1,143 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.ant.tasks;
+
+import java.io.File;
+import java.io.IOException;
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Proxy;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.apache.maven.plugins.antrun.AntRunMojo;
+import org.apache.maven.plugins.antrun.MavenAntRunProject;
+import org.apache.maven.project.MavenProject;
+import org.apache.maven.project.MavenProjectHelper;
+import org.apache.tools.ant.BuildException;
+import org.apache.tools.ant.Project;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Test class for {@link AttachArtifactTask}.
+ */
+class AttachArtifactTaskTest {
+
+    private static final String CLASSIFIER = "tests";
+
+    private static final String TYPE = "jar";
+
+    @TempDir
+    Path folder;
+
+    private MavenProject attachedToProject;
+
+    private String attachedClassifier;
+
+    private String attachedType;
+
+    private File attachedFile;
+
+    /**
+     * The task must also accept a plain {@link MavenProject} reference, such as the {@code maven.project} reference
+     * registered by {@link AntRunMojo}, instead of throwing a {@link ClassCastException}.
+     *
+     * @throws IOException In case of problems
+     */
+    @Test
+    void executesWhenProjectReferenceIsMavenProject() throws IOException {
+        MavenProject mavenProject = new MavenProject();
+        AttachArtifactTask task = newTask(AntRunMojo.DEFAULT_MAVEN_PROJECT_REFID, mavenProject);
+
+        task.execute();
+
+        assertEquals(mavenProject, attachedToProject);
+        assertEquals(TYPE, attachedType);
+        assertEquals(CLASSIFIER, attachedClassifier);
+        assertEquals(task.getFile(), attachedFile);
+    }
+
+    /**
+     * The default {@code maven.project.ref} reference, which wraps the project in a {@link MavenAntRunProject}, keeps
+     * working.
+     *
+     * @throws IOException In case of problems
+     */
+    @Test
+    void executesWhenProjectReferenceIsMavenAntRunProject() throws IOException {
+        MavenProject mavenProject = new MavenProject();
+        AttachArtifactTask task =
+                newTask(AntRunMojo.DEFAULT_MAVEN_PROJECT_REF_REFID, new MavenAntRunProject(mavenProject));
+
+        task.execute();
+
+        assertEquals(mavenProject, attachedToProject);
+    }
+
+    /**
+     * An incompatible reference type must be rejected with a clear {@link BuildException} rather than a raw
+     * {@link ClassCastException}.
+     *
+     * @throws IOException In case of problems
+     */
+    @Test
+    void throwsBuildExceptionWhenProjectReferenceHasIncompatibleType() throws IOException {
+        AttachArtifactTask task = newTask(AntRunMojo.DEFAULT_MAVEN_PROJECT_REFID, "not a project");
+
+        BuildException exception = assertThrows(BuildException.class, task::execute);
+
+        assertTrue(exception.getMessage().contains("Maven project reference"));
+    }
+
+    private AttachArtifactTask newTask(String projectRefId, Object projectReference) throws IOException {
+        MavenProjectHelper projectHelper = newHelperStub();
+
+        Project antProject = new Project();
+        antProject.addReference(projectRefId, projectReference);
+        antProject.addReference(AntRunMojo.DEFAULT_MAVEN_PROJECT_HELPER_REFID, projectHelper);
+
+        File file = Files.createTempFile(folder, "artifact", "." + TYPE).toFile();
+
+        AttachArtifactTask task = new AttachArtifactTask();
+        task.setProject(antProject);
+        task.setMavenProjectRefId(projectRefId);
+        task.setFile(file);
+        task.setClassifier(CLASSIFIER);
+        task.setType(TYPE);
+        return task;
+    }
+
+    private MavenProjectHelper newHelperStub() {
+        InvocationHandler handler = (proxy, method, args) -> {
+            if ("attachArtifact".equals(method.getName()) && args.length == 4) {
+                attachedToProject = (MavenProject) args[0];
+                attachedType = (String) args[1];
+                attachedClassifier = (String) args[2];
+                attachedFile = (File) args[3];
+            }
+            return null;
+        };
+        return (MavenProjectHelper)
+                Proxy.newProxyInstance(getClass().getClassLoader(), new Class<?>[] {MavenProjectHelper.class}, handler);
+    }
+}


### PR DESCRIPTION
Fixes #375

## Summary

`AttachArtifactTask` cast the reference resolved from `mavenProjectRefId` to `MavenAntRunProject` unconditionally. When the attribute pointed at a plain `MavenProject` reference (e.g. `maven.project`, which `AntRunMojo` also registers), the task threw a raw `ClassCastException`.

## Changes

- `AttachArtifactTask.java`: resolve the Maven project by type. A `MavenAntRunProject` reference is unwrapped, a `MavenProject` reference is used directly, and any other type is rejected with a clear `BuildException` instead of a `ClassCastException`.
- New unit test `AttachArtifactTaskTest` covering:
  - `mavenProjectRefId` pointing at a plain `MavenProject` (previously `ClassCastException`),
  - the default `MavenAntRunProject` wrapper keeps working,
  - an incompatible reference type is rejected with a `BuildException`.

## Verification

- New tests fail on master (`ClassCastException`) and pass with the fix.
- `mvn verify` (rat, checkstyle, spotless, unit tests, javadoc) passes.
- `mvn verify -Prun-its` passes: all 29 integration tests succeed.
