### PR TITLE
Restore the document metadata dropped when the pages were ported

### DIFF
--- a/src/site/markdown/examples/classpaths.md.vm
+++ b/src/site/markdown/examples/classpaths.md.vm
@@ -1,3 +1,10 @@
+---
+title: Using the classpaths
+author: 
+  - Carlos Sanchez, Franz Allan Valencia See
+date: 2006-07-27
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file

--- a/src/site/markdown/examples/customTasks.md.vm
+++ b/src/site/markdown/examples/customTasks.md.vm
@@ -1,3 +1,10 @@
+---
+title: Using tasks not included in Ant's default jar
+author: 
+  - Carlos Sanchez
+date: 2008-07-15
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file

--- a/src/site/markdown/examples/tasksAttributes.md.vm
+++ b/src/site/markdown/examples/tasksAttributes.md.vm
@@ -1,3 +1,10 @@
+---
+title: Using tasks attributes
+author: 
+  - Vincent Siveton
+date: 2006-09-30
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file

--- a/src/site/markdown/index.md
+++ b/src/site/markdown/index.md
@@ -1,3 +1,10 @@
+---
+title: Introduction
+author: 
+  - Kenney Westerhof, Franz Allan Valencia See
+date: 2013-07-22
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file

--- a/src/site/markdown/tasks/attachArtifact.md.vm
+++ b/src/site/markdown/tasks/attachArtifact.md.vm
@@ -1,3 +1,10 @@
+---
+title: AttachArtifact Task
+author: 
+  - Paul Gier
+date: 2010-05-21
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file

--- a/src/site/markdown/tasks/dependencyFilesets.md.vm
+++ b/src/site/markdown/tasks/dependencyFilesets.md.vm
@@ -1,3 +1,10 @@
+---
+title: DependencyFileSets Task
+author: 
+  - Paul Gier
+date: 2010-03-19
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file

--- a/src/site/markdown/tasks/tasks.md
+++ b/src/site/markdown/tasks/tasks.md
@@ -1,3 +1,10 @@
+---
+title: Ant Tasks
+author: 
+  - Paul Gier
+date: 2010-03-19
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file

--- a/src/site/markdown/tasks/versionMapper.md.vm
+++ b/src/site/markdown/tasks/versionMapper.md.vm
@@ -1,3 +1,10 @@
+---
+title: VersionMapper
+author: 
+  - Paul Gier
+date: 2010-05-21
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file

--- a/src/site/markdown/usage.md.vm
+++ b/src/site/markdown/usage.md.vm
@@ -1,3 +1,10 @@
+---
+title: Usage
+author: 
+  - Kenney Westerhof, Franz Allan Valencia See, Vincent Siveton
+date: 2006-09-30
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file


### PR DESCRIPTION
The site pages lost their document metadata when they were ported from APT.

An APT document opens with a header block giving its title, authors and date, and
`doxia-converter` turns that into YAML front matter. The port dropped the front matter
along with the converter's per-line licence comments, so the generated pages lost their
`<meta name="author">` and date, and took their `<title>` from the first heading instead
of from the document title.

Building one project's site from the APT sources and from the ported Markdown shows the
difference:

| | `<title>` produced |
|---|---|
| APT original | `Release Notes - Modello` |
| ported Markdown | `Modello - Modello` |
| with this change | `Release Notes - Modello` |

The front matter has to come first in the file, because the Markdown parser only looks
for it when the source begins with `---`; a licence header ahead of it would hide it.
RAT is happy either way.

Verified by building the site before and after and comparing `<title>` and the author
meta tags of every generated page, and by confirming the front matter does not reach
the rendered body.