### PR TITLE
Restore the common wording on the download page

### DIFF
--- a/src/site/xdoc/download.xml.vm
+++ b/src/site/xdoc/download.xml.vm
@@ -29,9 +29,9 @@ under the License.
 
       <p><strong>${project.name} ${project.version}</strong> is distributed in source format.</p>
 
-      <p>Use a source archive to build <strong>${project.name}</strong> yourself.</p>
+      <p>Use a source archive if you intend to build <strong>${project.name}</strong> yourself.</p>
 
-      <p>Otherwise, use the ready-made binary artifacts from the <strong>central repository</strong>.</p>
+      <p>Otherwise, simply use the ready-made binary artifacts from <strong>central repository</strong>.</p>
 
       <p><strong>${project.name}</strong> is distributed under the <a href="https://www.apache.org/licenses/">Apache License, version 2.0</a>.</p>
 
@@ -58,16 +58,16 @@ under the License.
           </tbody>
         </table>
 
-        <p>Verify the integrity of the downloaded file. Use the checksum
-          (.sha512 file) or the signature (.asc file). Verify the signature
-          against the public <a href="https://downloads.apache.org/maven/KEYS">KEYS</a> used by the Apache Maven developers.
+        <p>It is essential that you <a href="https://www.apache.org/info/verification.html">verify the integrity</a> of the downloaded file
+          using the checksum (.sha512 file)
+          or using the signature (.asc file) against the public <a href="https://downloads.apache.org/maven/KEYS">KEYS</a> used by the Apache Maven developers.
         </p>
 
       </subsection>
 
       <subsection name="Previous Versions">
-        <p>Use the latest release version of <strong>${project.name}</strong>. The latest version has the newest features and bug fixes.</p>
-        <p>You can find older releases on the <a href="https://archive.apache.org/dist/maven/plugins/">archive site</a>.</p>
+        <p>It is strongly recommended to use the latest release version of <strong>${project.name}</strong> to take advantage of the newest features and bug fixes.</p>
+        <p>Older non-recommended releases can be found on our <a href="https://archive.apache.org/dist/maven/plugins/">archive site</a>.</p>
       </subsection>
     </section>
   </body>


### PR DESCRIPTION
The wording on this page had drifted from the text the rest of the Maven estate uses. This restores the shared form so the page is identical to its counterparts apart from the distribution area and the artifact name.

This is worth doing rather than cosmetic: in `apache/maven-shared-utils` the same kind of rewording had **silently dropped three hyperlinks** — the verification instructions, the KEYS file and the archive site — leaving them as plain prose. A link-set audit was run across every repository in this sweep to catch that class of loss.

No URL and no in-page anchor changes. `download.cgi` is left in place. The ASF licence header is left byte-for-byte as it was.

### Verification

Generated from a single canonical template that reproduces the existing form exactly; XML well-formedness checked and the link set compared before and after. Representative repositories were rendered before and after with a real site build. **This specific repository was not individually rendered** unless noted. Draft until CI is green.