### PR TITLE
Skip dependencies with no resolved artifact file instead of throwing NPE

### DIFF
--- a/src/main/java/org/apache/maven/plugins/antrun/AntRunMojo.java
+++ b/src/main/java/org/apache/maven/plugins/antrun/AntRunMojo.java
@@ -429,11 +429,7 @@ public class AntRunMojo extends AbstractMojo {
 
         // Add properties for dependency artifacts
         Set<Artifact> depArtifacts = mavenProject.getArtifacts();
-        for (Artifact artifact : depArtifacts) {
-            String propName = artifact.getDependencyConflictId();
-
-            antProject.setProperty(propertyPrefix + propName, artifact.getFile().getPath());
-        }
+        setDependencyFileProperties(depArtifacts, antProject);
 
         // Add a property containing the list of versions for the mapper
         StringBuilder versionsBuffer = new StringBuilder();
@@ -441,6 +437,37 @@ public class AntRunMojo extends AbstractMojo {
             versionsBuffer.append(artifact.getVersion()).append(File.pathSeparator);
         }
         antProject.setProperty(versionsPropertyName, versionsBuffer.toString());
+    }
+
+    /**
+     * Registers one <code>${propertyPrefix}${dependencyConflictId}</code> property per dependency,
+     * holding the path to that dependency's artifact file.
+     * <p>
+     * An artifact's file may be <code>null</code> when it was never resolved, for instance under
+     * partial or offline resolution. Such dependencies are skipped with a warning naming them,
+     * rather than aborting the build: the property is simply absent, so a build that never
+     * references it still runs.
+     *
+     * @param depArtifacts the project's dependency artifacts, may be null
+     * @param antProject the Ant project to set properties on, not null
+     */
+    void setDependencyFileProperties(Set<Artifact> depArtifacts, Project antProject) {
+        if (depArtifacts == null) {
+            return;
+        }
+
+        for (Artifact artifact : depArtifacts) {
+            String propName = artifact.getDependencyConflictId();
+
+            File artifactFile = artifact.getFile();
+            if (artifactFile == null) {
+                getLog().warn("Not setting property \"" + propertyPrefix + propName + "\": dependency "
+                        + artifact.getId() + " has no resolved artifact file.");
+                continue;
+            }
+
+            antProject.setProperty(propertyPrefix + propName, artifactFile.getPath());
+        }
     }
 
     /**

--- a/src/test/java/org/apache/maven/plugins/antrun/AntRunMojoDependencyPropertiesTest.java
+++ b/src/test/java/org/apache/maven/plugins/antrun/AntRunMojoDependencyPropertiesTest.java
@@ -1,0 +1,110 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.plugins.antrun;
+
+import java.io.File;
+import java.lang.reflect.Field;
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+import org.apache.maven.artifact.Artifact;
+import org.apache.maven.artifact.DefaultArtifact;
+import org.apache.maven.artifact.handler.DefaultArtifactHandler;
+import org.apache.maven.artifact.versioning.VersionRange;
+import org.apache.tools.ant.Project;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+/**
+ * A dependency whose artifact was never resolved has a null file. Registering the
+ * per-dependency path properties must not fall over on it.
+ */
+class AntRunMojoDependencyPropertiesTest {
+
+    /**
+     * execute() defaults propertyPrefix to "" before any of this runs; a directly
+     * constructed mojo has not been through that, so mirror it here.
+     */
+    private static AntRunMojo mojoWithEmptyPrefix() throws Exception {
+        AntRunMojo mojo = new AntRunMojo(null);
+        Field prefix = AntRunMojo.class.getDeclaredField("propertyPrefix");
+        prefix.setAccessible(true);
+        prefix.set(mojo, "");
+        return mojo;
+    }
+
+    private static Artifact artifact(String artifactId, File file) {
+        Artifact artifact = new DefaultArtifact(
+                "org.example",
+                artifactId,
+                VersionRange.createFromVersion("1.0"),
+                "compile",
+                "jar",
+                null,
+                new DefaultArtifactHandler("jar"));
+        artifact.setFile(file);
+        return artifact;
+    }
+
+    @Test
+    void unresolvedDependencyIsSkippedInsteadOfThrowing() throws Exception {
+        Set<Artifact> artifacts = new LinkedHashSet<>();
+        artifacts.add(artifact("unresolved", null));
+
+        Project antProject = new Project();
+        AntRunMojo mojo = mojoWithEmptyPrefix();
+
+        assertDoesNotThrow(() -> mojo.setDependencyFileProperties(artifacts, antProject));
+        assertNull(
+                antProject.getProperty("org.example:unresolved:jar"),
+                "no path property should be set for a dependency with no artifact file");
+    }
+
+    @Test
+    void resolvedDependenciesStillGetTheirPathProperty() throws Exception {
+        File resolved = new File("target", "resolved-1.0.jar");
+
+        Set<Artifact> artifacts = new LinkedHashSet<>();
+        artifacts.add(artifact("unresolved", null));
+        artifacts.add(artifact("resolved", resolved));
+
+        Project antProject = new Project();
+        AntRunMojo mojo = mojoWithEmptyPrefix();
+
+        mojo.setDependencyFileProperties(artifacts, antProject);
+
+        // The unresolved artifact is listed first, so this also proves one bad
+        // dependency no longer prevents the rest from being registered.
+        assertEquals(
+                resolved.getPath(),
+                antProject.getProperty("org.example:resolved:jar"),
+                "resolved dependencies must still get their path property");
+    }
+
+    @Test
+    void nullArtifactSetIsTolerated() throws Exception {
+        Project antProject = new Project();
+        AntRunMojo mojo = mojoWithEmptyPrefix();
+
+        assertDoesNotThrow(() -> mojo.setDependencyFileProperties(null, antProject));
+    }
+}


### PR DESCRIPTION
Fixes #372.

## Problem

`copyProperties(MavenProject, Project)` registers one path property per dependency:

```java
for (Artifact artifact : depArtifacts) {
    String propName = artifact.getDependencyConflictId();
    antProject.setProperty(propertyPrefix + propName, artifact.getFile().getPath());
}
```

`artifact.getFile()` is `null` when the artifact was never resolved — partial or offline resolution, for example — so the mojo aborts with a bare `NullPointerException` that names nothing:

```
java.lang.NullPointerException: Cannot invoke "java.io.File.getPath()"
  because the return value of "org.apache.maven.artifact.Artifact.getFile()" is null
```

Nothing in that tells the user which dependency is at fault.

## Fix

Skip such dependencies with a warning that names the artifact:

```
[WARNING] Not setting property "org.example:unresolved:jar": dependency
org.example:unresolved:jar:1.0 has no resolved artifact file.
```

The property is simply absent, so a build that never references it still runs, and one unresolvable dependency no longer prevents the remaining ones from being registered.

### Why skip rather than throw

The issue notes `getPathFromArtifacts` throws `DependencyResolutionRequiredException` in the same situation, and consistency with it would be reasonable. I did not do that here because **`copyProperties` is public and does not declare `throws`** — adding a checked exception to it would break any caller outside this plugin. Skipping fixes the crash without touching the published signature.

If you would rather have the failure, I am happy to switch it: the natural shape would be deprecating the current `copyProperties` and adding one declared to throw, which is a larger change than this issue needs. Your call.

## Tests

The loop moved into a package-private `setDependencyFileProperties(Set<Artifact>, Project)` so it can be tested at all — `copyProperties` itself requires a `MavenSession` and a POM file, and this project has no mocking framework, so testing it directly would have meant adding one as a dependency. The extraction keeps the public API unchanged.

Three cases, using `DefaultArtifact` (whose `getFile()` is null unless set), so no mocks are needed:

| test | before | after |
|---|---|---|
| `unresolvedDependencyIsSkippedInsteadOfThrowing` | ERROR — NPE | pass |
| `resolvedDependenciesStillGetTheirPathProperty` | FAIL — NPE aborts before the resolved one is reached | pass |
| `nullArtifactSetIsTolerated` | pass | pass |

The second lists the unresolved artifact *first*, so it also proves one bad dependency no longer blocks the rest.

```
before fix:  Tests run: 3, Failures: 1, Errors: 1
after fix:   Tests run: 3, Failures: 0, Errors: 0
full suite:  Tests run: 7, Failures: 0, Errors: 0
```